### PR TITLE
This will add the priorly discussed recruitment policy

### DIFF
--- a/RecruitmentPolicy.md
+++ b/RecruitmentPolicy.md
@@ -1,0 +1,40 @@
+
+# tech404.io Recruitment Policy
+
+####Last updated: October 19th, 2016
+
+##Goals
+
+* Get people jobs they can do from Atlanta, if they want jobs
+
+* Get people gigs they can do from Atlanta, if they want gigs
+
+* Leave people alone, in peace, if they want neither of these things: Feeling pursued when you don’t want to be is both uncomfortable and unwelcoming
+
+##Specific Policies 
+
+###All Jobs/Gigs Postings:
+
+Do not post them if they cannot be done from a chair in Atlanta. Remote is fine as long as the person is in Atlanta while doing it.
+
+Do not post generic referral links. 
+
+Specific referral links to specific jobs/gigs are fine.
+
+Do not recruit people in unsolicited DMs. Post publicly and let them come to you. Ask them to DM you in your posting. Talking in channel with them is fine.
+
+###Non-recruiting topic channels (E.g. Docker, Ruby, etc):
+
+Don't recruit there. If you're in the market for jobs or gigs, go to #jobs or #gigs, and set slack keywords if you want it to notify you.
+
+###Recruiters: 
+
+Do not Direct Message(DM) anyone first unless they specifically have asked for DMs **in their profile** or **in a channel** from "recruiters”, or “everybody/anybody/all opportunities“. 
+
+You may also DM people first if they specifically invite you to DM them. 
+
+Screenshot the permissions you were given if you want to be very safe, as we may enforce this rule without warning and ban you after one reported transgression. 
+
+###Reporting: 
+
+If anyone DMs you without permission, report it to an admin. **We will look into it**, but may not act immediately in a visible direction. Managing recruiting activity is a bit of an adversarial process at times, so we may not be able to be 100% transparent in what is going on to anyone.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,5 +7,7 @@
     <a href="https://github.com/tech404/CoC">Code of Conduct</a>
     &middot;
     <a href="https://github.com/tech404">The Github Project</a>
+    &middot;
+    <a href="https://github.com/tech404/RecruitmentPolicy">Recruitment Policy</a>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,6 @@
     &middot;
     <a href="https://github.com/tech404">The Github Project</a>
     &middot;
-    <a href="https://github.com/tech404/RecruitmentPolicy">Recruitment Policy</a>
+    <a href="https://github.com/tech404/tech404.io/blob/gh-pages/RecruitmentPolicy.md">Recruitment Policy</a>
   </div>
 </footer>


### PR DESCRIPTION
This adds the recruitment policy. This works only once accepted due to the fact it's linking back to github. 

If you'd like to test it, change the "tech404" organization name in the footer to "langford" and it will link to this fork.