### PR TITLE
Allows remote jobs that could be done from anywhere

### DIFF
--- a/RecruitmentPolicy.md
+++ b/RecruitmentPolicy.md
@@ -15,7 +15,7 @@
 
 ###All Jobs/Gigs Postings:
 
-Do not post them if they cannot be done from a chair in Atlanta. Remote is fine as long as the person is in Atlanta while doing it.
+Do not post them if they cannot be done from a chair in Atlanta. Remote is fine as long as the person can be in Atlanta while doing it.
 
 Do not post generic referral links. 
 


### PR DESCRIPTION
Someone brought up that a literal reading could mean a job that said literally "work from anywhere" was contrary to the former version of the rules. This version shifts a "is" to "can" allowing the category of jobs that allow work anywhere. 

I do not believe we intended to exclude them, and reception to this possible change seems positive.