### PR TITLE
Fix formatting on recruitment markdown page

### DIFF
--- a/RecruitmentPolicy.md
+++ b/RecruitmentPolicy.md
@@ -1,8 +1,8 @@
 # tech404 Recruitment Policy
 
-####Last updated: October 19th, 2016
+#### Last updated: October 19th, 2016
 
-##Goals
+## Goals
 
 * Get people jobs they can do from Atlanta, if they want jobs
 
@@ -10,9 +10,9 @@
 
 * Leave people alone, in peace, if they want neither of these things: Feeling pursued when you don’t want to be is both uncomfortable and unwelcoming
 
-##Specific Policies 
+## Specific Policies 
 
-###All Jobs/Gigs Postings:
+### All Jobs/Gigs Postings:
 
 Do not post them if they cannot be done from a chair in Atlanta. Remote is fine as long as the person is in Atlanta while doing it.
 
@@ -22,11 +22,11 @@ Specific referral links to specific jobs/gigs are fine.
 
 Do not recruit people in unsolicited DMs. Post publicly and let them come to you. Ask them to DM you in your posting. Talking in channel with them is fine.
 
-###Non-recruiting topic channels (E.g. Docker, Ruby, etc):
+### Non-recruiting topic channels (E.g. Docker, Ruby, etc):
 
 Don't recruit there. If you're in the market for jobs or gigs, go to #jobs or #gigs, and set slack keywords if you want it to notify you.
 
-###Recruiters: 
+### Recruiters: 
 
 Do not Direct Message(DM) anyone first unless they specifically have asked for DMs **in their profile** or **in a channel** from "recruiters”, or “everybody/anybody/all opportunities“. 
 
@@ -34,6 +34,6 @@ You may also DM people first if they specifically invite you to DM them.
 
 Screenshot the permissions you were given if you want to be very safe, as we may enforce this rule without warning and ban you after one reported transgression. 
 
-###Reporting: 
+### Reporting: 
 
 If anyone DMs you without permission, report it to an admin. **We will look into it**, but may not act immediately in a visible direction. Managing recruiting activity is a bit of an adversarial process at times, so we may not be able to be 100% transparent in what is going on to anyone.


### PR DESCRIPTION
This makes the recruitment markdown document render on GitHub as I expect was the intent.